### PR TITLE
Fix os version check

### DIFF
--- a/CIS Scripts/2_Security_Audit_Compliance.sh
+++ b/CIS Scripts/2_Security_Audit_Compliance.sh
@@ -54,8 +54,8 @@ hardwareUUID="$(/usr/sbin/system_profiler SPHardwareDataType | grep "Hardware UU
 
 logFile="/Library/Application Support/SecurityScoring/remediation.log"
 
-osVersion="$(sw_vers -productversion)"
-if [ "$osVersion" < 11 ]; then
+osMajorVersion="$(sw_vers -productVersion | cut -d. -f1)"
+if [ "$osMajorVersion" -lt 11 ]; then
 	echo "This script does not support Catalina. Please use https://github.com/jamf/CIS-for-macOS-Catalina-CP instead"
 	exit 0
 fi


### PR DESCRIPTION
1- `sw_vers` require capital V on `-productVersion`
2- `<` doesn't work on bash. Should use `-lt`
3- the version cannot be simply compared with `-lt` as it is a string with multiple `.` (dots). So I changed to get only the Major version (it would have `11` if the command returns `11.3.1`)